### PR TITLE
implementing serialization and deserialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # pyxorfilter
 
-[![Build Status](https://travis-ci.org/glitzflitz/pyxorfilter.svg?branch=master)](https://travis-ci.org/glitzflitz/pyxorfilter)
-
 Python bindings for [C](https://github.com/FastFilter/xor_singleheader) implementation of [Xor Filters: Faster and Smaller Than Bloom and Cuckoo Filters](https://arxiv.org/abs/1912.08258)
 and of [Binary Fuse Filters: Fast and Smaller Than Xor Filters](https://arxiv.org/abs/2201.01174).
 ## Installation
@@ -32,6 +30,16 @@ False
 >>> filter.size_in_bytes()
 60
 ```
+
+You can serialize a filter with the `serialize()` method which returns a buffer, and you can recover the filter with the `deserialize(buffer)` method, which returns a filter:
+
+```py
+> f = open('/tmp/output', 'wb')
+> f.write(filter.serialize())
+> f.close()
+> recoverfilter = Xor8.deserialize(open('/tmp/output', 'rb').read())
+```
+
 ## Caveats
 ### Accuracy
 For more accuracy(less false positives) use larger but more accurate Xor16 for Fuse16.
@@ -46,9 +54,6 @@ For large sets (contain millions of keys), Fuse8/Fuse16 filters are faster and s
 >>> filter.size_in_bytes()
 1130536
 ```
-
-### Overflow
-Both Xor8/Fuse8 and Xor16/Fuse16 take uint8_t and uint_16t respectively. Make sure that the input is unsigned.
 
 ### TODO
 

--- a/pyxorfilter/ffibuild.py
+++ b/pyxorfilter/ffibuild.py
@@ -151,6 +151,21 @@ bool xor16_buffered_populate(const uint64_t *keys, uint32_t size, xor16_t *filte
 bool xor16_populate(const uint64_t *keys, uint32_t size, xor16_t *filter) ;
 bool binary_fuse16_populate(const uint64_t *keys, uint32_t size, binary_fuse16_t *filter) ;
 
+
+size_t xor16_serialization_bytes(xor16_t *filter);
+size_t xor8_serialization_bytes(const xor8_t *filter);
+void xor16_serialize(const xor16_t *filter, char *buffer);
+void xor8_serialize(const xor8_t *filter, char *buffer);
+bool xor16_deserialize(xor16_t * filter, const char *buffer);
+bool xor8_deserialize(xor8_t * filter, const char *buffer);
+
+size_t binary_fuse16_serialization_bytes(binary_fuse16_t *filter);
+size_t binary_fuse8_serialization_bytes(const binary_fuse8_t *filter);
+void binary_fuse16_serialize(const binary_fuse16_t *filter, char *buffer);
+void binary_fuse8_serialize(const binary_fuse8_t *filter, char *buffer);
+bool binary_fuse16_deserialize(binary_fuse16_t * filter, const char *buffer);
+bool binary_fuse8_deserialize(binary_fuse8_t * filter, const char *buffer);
+
 """
 )
 

--- a/pyxorfilter/pyxorfilter.py
+++ b/pyxorfilter/pyxorfilter.py
@@ -7,7 +7,6 @@ class Xor8:
     def __init__(self, size):
         self.__filter = ffi.new("xor8_t *")
         status = lib.xor8_allocate(size, self.__filter)
-        self.size = size
         if not status:
             print("Unable to allocate memory for 8 bit filter")
 
@@ -33,6 +32,18 @@ class Xor8:
 
     def size_in_bytes(self):
         return lib.xor8_size_in_bytes(self.__filter)
+    
+    def serialize(self):
+        buffer = ffi.new("char[]", lib.xor8_serialization_bytes(self.__filter))
+        lib.xor8_serialize(self.__filter, buffer)
+        return ffi.buffer(buffer)
+
+    @staticmethod
+    def deserialize(buffer):
+        self = object.__new__(Xor8)
+        self.__filter = ffi.new("xor8_t *")
+        lib.xor8_deserialize(self.__filter, ffi.from_buffer(buffer))
+        return self
 
 
 class Xor16:
@@ -62,13 +73,22 @@ class Xor16:
     def size_in_bytes(self):
         return lib.xor16_size_in_bytes(self.__filter)
 
+    def serialize(self):
+        buffer = ffi.new("char[]", lib.xor16_serialization_bytes(self.__filter))
+        lib.xor16_serialize(self.__filter, buffer)
+        return ffi.buffer(buffer)
 
+    @staticmethod
+    def deserialize(buffer):
+        self = object.__new__(Xor16)
+        self.__filter = ffi.new("xor16_t *")
+        lib.xor16_deserialize(self.__filter, ffi.from_buffer(buffer))
+        return self
 
 class Fuse8:
     def __init__(self, size):
         self.__filter = ffi.new("binary_fuse8_t *")
         status = lib.binary_fuse8_allocate(size, self.__filter)
-        self.size = size
         if not status:
             print("Unable to allocate memory for 8 bit filter")
 
@@ -95,13 +115,22 @@ class Fuse8:
     def size_in_bytes(self):
         return lib.binary_fuse8_size_in_bytes(self.__filter)
 
+    def serialize(self):
+        buffer = ffi.new("char[]", lib.binary_fuse8_serialization_bytes(self.__filter))
+        lib.binary_fuse8_serialize(self.__filter, buffer)
+        return ffi.buffer(buffer)
 
+    @staticmethod
+    def deserialize(buffer):
+        self = object.__new__(Fuse8)
+        self.__filter = ffi.new("binary_fuse8_t *")
+        lib.binary_fuse8_deserialize(self.__filter, ffi.from_buffer(buffer))
+        return self
 
 class Fuse16:
     def __init__(self, size):
         self.__filter = ffi.new("binary_fuse16_t *")
         status = lib.binary_fuse16_allocate(size, self.__filter)
-        self.size = size
         if not status:
             print("Unable to allocate memory for 16 bit filter")
 
@@ -127,3 +156,15 @@ class Fuse16:
 
     def size_in_bytes(self):
         return lib.binary_fuse16_size_in_bytes(self.__filter)
+
+    def serialize(self):
+        buffer = ffi.new("char[]", lib.binary_fuse16_serialization_bytes(self.__filter))
+        lib.binary_fuse16_serialize(self.__filter, buffer)
+        return ffi.buffer(buffer)
+
+    @staticmethod
+    def deserialize(buffer):
+        self = object.__new__(Fuse16)
+        self.__filter = ffi.new("binary_fuse16_t *")
+        lib.binary_fuse16_deserialize(self.__filter, ffi.from_buffer(buffer))
+        return self


### PR DESCRIPTION
This PR adds the ability to serialize and deserialize the filters to a byte buffer which can be saved to disk or network.

```py
> f = open('/tmp/output', 'wb')
> f.write(filter.serialize())
> f.close()
> recoverfilter = Xor8.deserialize(open('/tmp/output', 'rb').read())
```

Fixes https://github.com/glitzflitz/pyxorfilter/issues/5