### PR TITLE
making sure that C headers are included in source distribution (sdist)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include lib/xor_singleheader/include/binaryfusefilter.h
+include lib/xor_singleheader/include/xorfilter.h 


### PR DESCRIPTION
Currently, this module cannot be installed from a source distribution since the C header files are not included.

You can see in the logs that with this manifest file, the issue should be fixed:

<img width="934" alt="Screenshot 2024-03-31 at 1 38 45 PM" src="https://github.com/glitzflitz/pyxorfilter/assets/391987/e457d0a3-7977-4200-96ef-62d9e108cacd">
